### PR TITLE
Optimized Sign and Abs functions by replacing comparison with bitwise operators

### DIFF
--- a/FixPointCS/Fixed64.cs
+++ b/FixPointCS/Fixed64.cs
@@ -280,8 +280,9 @@ namespace FixPointCS
         [MethodImpl(FixedUtil.AggressiveInlining)]
         public static int Sign(long x)
         {
-            if (x == 0) return 0;
-            return (x < 0) ? -1 : 1;
+            //https://stackoverflow.com/questions/14579920/fast-sign-of-integer-in-c/14612418#14612418
+            const int BITS_MINUS_ONE = sizeof(long) * 8 - 1;
+            return (int) (((long) x >> BITS_MINUS_ONE) | (long) (((ulong) -(long) x) >> BITS_MINUS_ONE));
         }
 
         /// <summary>

--- a/FixPointCS/Fixed64.cs
+++ b/FixPointCS/Fixed64.cs
@@ -189,8 +189,12 @@ namespace FixPointCS
         public static long Abs(long x)
         {
             // \note fails with LONG_MIN
-            // \note for some reason this is twice as fast as (x > 0) ? x : -x
-            return (x < 0) ? -x : x;
+            // \note for some reason (x < 0) ? -x : x is twice as fast as (x > 0) ? x : -x
+            
+            // branchless implementation, see http://www.strchr.com/optimized_abs_function
+            const int BITS_MINUS_ONE = sizeof(long) * 8 - 1;
+            var mask = x >> BITS_MINUS_ONE;
+            return (x + mask) ^ mask;
         }
 
         /// <summary>
@@ -199,7 +203,7 @@ namespace FixPointCS
         [MethodImpl(FixedUtil.AggressiveInlining)]
         public static long Nabs(long x)
         {
-            return (x > 0) ? -x : x;
+            return -Abs(x);
         }
 
         /// <summary>


### PR DESCRIPTION
Here is a benchmark and a test to check that it really does the same:
https://dotnetfiddle.net/p5n8Oq
https://dotnetfiddle.net/aANrDr

The speedup is only about 8% in that online test, but in my computer (with an AMD FX-8350) it is twice as fast.

![image](https://user-images.githubusercontent.com/5580666/53302788-8755ac00-3862-11e9-9770-4ce14f280c77.png)
